### PR TITLE
Update security update defaults

### DIFF
--- a/docs/manuals/ubuntu-security-updates.qmd
+++ b/docs/manuals/ubuntu-security-updates.qmd
@@ -2,13 +2,13 @@
 title: How to activate security updates on Ubuntu
 ---
 
-Please take a moment to read the [security recommendations for VREs](../responsible-use.qmd#vre-lifetime-and-security-updates). If you wish to keep using the same VRE for longer than 3 weeks, please consider turning on automatic security updates for the VRE's OS. This manual describes how to enable these for any VREs running Ubuntu Linux.
+Please take a moment to read the [security recommendations for VREs](../responsible-use.qmd#vre-lifetime-and-security-updates). If you wish to keep using the same VRE for longer than 3 weeks, automatic security updates for the VRE's OS must be turned on. This manual describes how to enable these for any VREs running Ubuntu Linux. **At the moment security updates for Ubuntu are turned on by default on ResearchCloud, so no action should be necessary. This manual exists in case this default setting changes in the future.**
 
 [Contact us](../contact.qmd) if you run into any problems with the instructions below.
 
-### Understanding automatic security updates for Ubuntu
+## Understanding automatic security updates for Ubuntu
 
-The Ubuntu OS has a feature called "unattended upgrades" that will automatically install security updates for installed packages as they become available. These are not enabled on ResearchCloud by default because ResearchCloud workspaces are envisioned as machines running for only a limited time. However, you can easily activate the feature yourself, as long as you have admin rights on the workspace.
+The Ubuntu OS has a feature called "unattended upgrades" that will automatically install security updates for installed packages as they become available. These are currently enabled on ResearchCloud by default. However, you can easily activate the feature yourself, as long as you have admin rights on the workspace.
 
 For longer-living workspaces, it is also heavily recommended to install a vulnerability scanning tool that actively monitors your workspace for weaknesses. Please [contact us](../contact.qmd) for help with this.
 
@@ -21,6 +21,8 @@ Advanced notes:
 
 * For almost all updates, the new version will become active immediately. This means that in very rare cases, an update may interfere with a running process. There is thus a tradeoff between security and stability, but such interference is rare and enabling unattended upgrades is considered best practice for Ubuntu servers.
 * There is one exception to the rule that updated versions will become automatically active: if the Linux kernel itself is updated, this will require a pause/resume of the workspace to become active. This happens rarely, but you can monitor for this by installing the aforementioned scanning tool ([contact us](../contact.qmd)).
+
+## Manually enabling automatic security updates
 
 ### Prerequisites
 

--- a/docs/responsible-use.qmd
+++ b/docs/responsible-use.qmd
@@ -133,9 +133,13 @@ app = App(app_ui, server)
 
 ## VRE lifetime and security updates
 
-The recommended maximum lifetime of a VRE (or workspace) is no more than 4 weeks. **A longer lifetime is only considered secure when the operating system is regulary updated by one of the users.** Users are responsible for keeping the installed software up to date (patching) with regard to security updates. By limiting the lifetime of a VRE you can minimize the risk of vulnerabilities by outdated software, because **everytime you create a new workspace, this will come with recent security updates already installed**.
+The recommended maximum lifetime of a VRE (or workspace) is no more than 4 weeks.
 
-Although some Catalog Items come with automatic security updates enabled by default, in most cases you will have to take action yourself. See [here](manuals/ubuntu-security-updates.qmd) for how to activate automatic updates on Ubuntu workspaces. Of course you can [contact us](contact.qmd) for help.
+**A longer lifetime is only considered secure when the operating system and applications are regulary updated and the workspace is by one of the users, and the workspace is actively monitored.**
+
+Users are responsible for keeping the installed software up to date (patching) with regard to security updates. By limiting the lifetime of a VRE you can minimize the risk of vulnerabilities by outdated software, because **everytime you create a new workspace, this will come with recent security updates already installed**.
+
+Ubuntu Linux workspaces on ResearchCloud currently have automatic operating system updates enabled by default. However, custom software that you may install (especially if they are server applications, like webapps) will still need to be patched and monitored. See [here](manuals/ubuntu-security-updates.qmd#understanding-automatic-security-updates-for-ubuntu) for more information. Of course you can [contact us](contact.qmd) for help.
 
 For longer-living workspaces, UU also requires use of scanning tools to scan active VRE's for security vulnerabilities. If the scan gives cause, the UU will contact you with the request to update software on VRE, and/or to take additional measures. If you intend to run longer-running workspaces, please [contact us](contact.qmd) and we can help to install the necessary scanning software.
 


### PR DESCRIPTION
@jelletreep SURF has enabled automatic updates by default, so I've 1) turned off the feature in the UU Provisioning component that enabled them, and 2) updates these docs. Could you have a look to see if the current formulations make sense?

I've opted to keep the manual on security updates for now, because it explains the difference between updates for packages in apt and other applications, and because you never know if it it might be necessary again in the future. But I could also rework it so that we only keep the information on different kinds of updates and remove the instructions for enabling automatic OS updates.