### PR TITLE
add workspace specific tables

### DIFF
--- a/docs/workspaces/plain/windows.qmd
+++ b/docs/workspaces/plain/windows.qmd
@@ -18,3 +18,24 @@ support: SURF, UU
 
 {{< include partials/_windows.qmd >}}
 
+
+Use this table to find the appropriate data transfer method for your situation:
+
+| Data Source | Recommended Tool | Best For | Skill Level |
+|------------|------------------|----------|-------------|
+| Yoda/iRODS | [iBridges](../../manuals/ibridges.qmd) (Pre-installed on "Windows with iBridges" flavor) | All file sizes, GUI interface | Beginner to Intermediate |
+| SURFdrive, ResearchDrive, OneDrive | [rclone](../../manuals/rclone-researchcloud.qmd) | Cloud storage sync, scheduled transfers | Intermediate (CLI) |
+| Your PC/laptop  | [scp](../../manuals/ssh-data-transfer-methods.qmd) | Direct one-time transfers | Intermediate (CLI) |
+| Your PC/laptop  | [rsync](../../manuals/ssh-data-transfer-methods.qmd) | Sync or repeated transfers | Intermediate (CLI) |
+| Your PC/laptop (Windows only) | [MobaXterm](https://servicedesk.surf.nl/wiki/spaces/WIKI/pages/92668162/Transfer+files+between+to+and+from+the+system#Transferfilesbetweentoandfromthesystem-SFTPforMobaXtermusers) | Graphical SSH/SFTP | Intermediate |
+| Your PC/laptop | [Cyberduck](https://servicedesk.surf.nl/wiki/spaces/WIKI/pages/112592488/Upload+data+to+a+workspace+with+Cyberduck) | Graphical SFTP client | Intermediate |
+| GitHub/GitLab | [git clone](../../manuals/git-clone.qmd) | Code repositories, version control | Intermediate (CLI) |
+
+:::{.callout-note}
+# Transferring Single Files via the Desktop Interface
+You can also transfer files directly from your PC to the workspace and vice-versa. **However, this works only for small and individual files**. 
+
+- Open your windows workspace.
+- In the top left, click on the three dots. Then select `Files` from the options that appear.
+- Here you can choose individual files to upload from your local PC to the workspace, or download files from the workspace to your local PC.
+:::

--- a/docs/workspaces/programming/jupyter.qmd
+++ b/docs/workspaces/programming/jupyter.qmd
@@ -42,9 +42,37 @@ You can login to the workspace in your browser, via [your ResearchCloud time-bas
 
 When logged in you are immediately presented with a JupyterLab environment in which you can work with different notebooks.
 
-{{< include ../partials/_data_transfer.qmd >}}
+### Data Transfer Jupyter Notebook
 
-You will have to run the relevant commands for the data transfer method of your choice from within [the JupyterLab terminal](https://jupyterlab.readthedocs.io/en/latest/user/terminal.html#terminals).
+Use this table to find the appropriate data transfer method for your situation:
+
+| Data Source | Recommended Tool | Best For | Skill Level |
+|------------|------------------|----------|-------------|
+| Your PC/laptop | [JupyterLab Upload button](#using-the-upload-button) | Small files, quick uploads | Beginner (GUI) |
+| Yoda/iRODS | [iBridges](../../manuals/ibridges.qmd) | All file sizes, CLI access | Beginner to Intermediate |
+| Yoda/iRODS | [iCommands](../../manuals/icommands.qmd) | Large datasets, transfer automation, CLI | Intermediate (CLI) |
+| SURFdrive, ResearchDrive, OneDrive | [rclone](../../manuals/rclone-researchcloud.qmd) | Cloud storage sync, scheduled transfers | Intermediate (CLI) |
+| Your PC/laptop | [scp](../../manuals/ssh-data-transfer-methods.qmd) | Direct one-time transfers | Intermediate (CLI) |
+| Your PC/laptop | [rsync](../../manuals/ssh-data-transfer-methods.qmd) | Sync or repeated transfers | Intermediate (CLI) |
+| Your PC/laptop (Windows only) | [MobaXterm](https://mobaxterm.mobatek.net/) | Graphical SSH/SFTP client | Intermediate |
+| Your PC/laptop | [Cyberduck](https://servicedesk.surf.nl/wiki/spaces/WIKI/pages/112592488/Upload+data+to+a+workspace+with+Cyberduck)| Graphical SFTP client | Intermediate |
+| GitHub/GitLab | [git clone](../../manuals/git-clone.qmd) | Code repositories, version control | Intermediate (CLI) |
+
+::: {.callout-tip #using-the-upload-button}
+### Using the Upload Button
+
+For small files, use the Upload button in the JupyterLab file browser (left sidebar):
+
+1. Click the **Upload Files** icon (↑) in the file browser toolbar
+2. Select files from your local computer
+3. Files will be uploaded to your current directory
+:::
+
+::: {.callout-note}
+All command-line tools (iBridges CLI, iCommands, rclone, scp/rsync, Git) must be run from the [JupyterLab terminal](https://jupyterlab.readthedocs.io/en/stable/user/terminal.html).
+:::
+
+See our [data transfer manuals](../../manuals.qmd#data-transfer) for detailed step-by-step guides.
 
 
 ### Installing additional software

--- a/docs/workspaces/programming/python-workbench.qmd
+++ b/docs/workspaces/programming/python-workbench.qmd
@@ -92,9 +92,24 @@ See the [poetry docs](https://python-poetry.org/docs/).
 Note that when you create a python environment using any of the tools above, you create a python environment for yourself only and not for others in your [Collaboration](../../glossary.qmd#collaboration). If you collaborate, you colleague should creaate their own python environment. We recommend collaborating using GitHub and `uv` (using a `uv.lock` file) to make sure your environments are the same. If this is not desired, create the environments in a shared location, like `/local-share`.
 :::
 
-{{< include ../partials/_data_transfer.qmd >}}
+### Data Transfer Options
 
-The recommended [iBridges client for Yoda and iRODS](../../manuals/ibridges.qmd) is preinstalled.
+Use this table to find the appropriate data transfer method for your situation:
+
+| Data Source | Recommended Tool | Best For | Skill Level |
+|------------|------------------|----------|-------------|
+| Yoda/iRODS | [iBridges](../../manuals/ibridges.qmd) (Recommended, pre-installed) | All file sizes, GUI and CLI access | Beginner to Intermediate |
+| Yoda/iRODS | [iCommands](../../manuals/icommands.qmd) | Large datasets, transfer automation, CLI | Intermediate (CLI) |
+| SURFdrive, ResearchDrive, OneDrive | [rclone](../../manuals/rclone-researchcloud.qmd) | Cloud storage sync, scheduled transfers | Intermediate (CLI) |
+| Your PC/laptop | Browser upload (Desktop only) | Small files, quick uploads | Beginner (GUI) |
+| Your PC/laptop | [scp](../../manuals/ssh-data-transfer-methods.qmd) | Direct one-time transfers | Intermediate (CLI) |
+| Your PC/laptop | [rsync](../../manuals/ssh-data-transfer-methods.qmd) | Sync or repeated transfers | Intermediate (CLI) |
+| Your PC/laptop (Windows only) | [MobaXterm](https://mobaxterm.mobatek.net/) | Graphical SSH/SFTP client | Intermediate |
+| Your PC/laptop | [Cyberduck](https://servicedesk.surf.nl/wiki/spaces/WIKI/pages/112592488/Upload+data+to+a+workspace+with+Cyberduck)| Graphical SFTP client | Intermediate |
+| GitHub/GitLab | [git clone](../../manuals/git-clone.qmd) | Code repositories, version control | Intermediate (CLI) |
+
+See our [data transfer manuals](../../manuals.qmd#data-transfer) for detailed step-by-step guides.
+
 
 #### VSCodium code editor (Desktop only)
 

--- a/docs/workspaces/programming/vre-lab.qmd
+++ b/docs/workspaces/programming/vre-lab.qmd
@@ -91,7 +91,23 @@ After logging in, you'll have access to the [JupyterLab](https://jupyterlab.read
  - Integrated [terminal](https://jupyterlab.readthedocs.io/en/latest/user/terminal.html#terminals) access
 
 {{< include ../partials/_data_transfer.qmd >}}
-You can also upload data directly to the workspace using the `Upload Files` button in the JupyterLab interface.
+
+Use this table to find the appropriate data transfer method for your situation:
+
+| Data Source | Recommended Tool | Best For | Skill Level |
+|------------|------------------|----------|-------------|
+| Your PC/laptop | JupyterLab Upload button | Small files, quick uploads | Beginner (GUI) |
+| Yoda/iRODS | [iBridges](../../manuals/ibridges.qmd) | All file sizes, CLI access | Beginner to Intermediate |
+| Yoda/iRODS | [iCommands](../../manuals/icommands.qmd) | Large datasets, transfer automation, CLI | Intermediate (CLI) |
+| SURFdrive, ResearchDrive, OneDrive | [rclone](../../manuals/rclone-researchcloud.qmd) | Cloud storage sync, scheduled transfers | Intermediate (CLI) |
+| Your PC/laptop | [scp](../../manuals/ssh-data-transfer-methods.qmd) | Direct one-time transfers | Intermediate (CLI) |
+| Your PC/laptop | [rsync](../../manuals/ssh-data-transfer-methods.qmd) | Sync or repeated transfers | Intermediate (CLI) |
+| Your PC/laptop (Windows only) | [MobaXterm](https://mobaxterm.mobatek.net/) | Graphical SSH/SFTP client | Intermediate |
+| Your PC/laptop | [Cyberduck](https://servicedesk.surf.nl/wiki/spaces/WIKI/pages/112592488/Upload+data+to+a+workspace+with+Cyberduck)| Graphical SFTP client | Intermediate |
+| GitHub/GitLab | [git clone](../../manuals/git-clone.qmd) | Code repositories, version control | Intermediate (CLI) |
+
+
+You can upload data directly to the workspace using the `Upload Files` button in the JupyterLab interface.
 
 ![Upload Files](../imgs/jupyter-upload-button.png){width=300px}
 


### PR DESCRIPTION
Adding the 4 workspace data transfer tables here. 
Removed the icommands option for windows. 
Rclone for windows is still there, but when i update the rclone documentation, i will include windows specific options too in the rclone manual