### PR TITLE
Update rclone documentation

### DIFF
--- a/docs/manuals/install-rclone.qmd
+++ b/docs/manuals/install-rclone.qmd
@@ -5,11 +5,18 @@ Title: "Install Rclone"
 The steps below are used to install Rclone on Research Cloud.
 
 ### Step 1: Make sure you are in a terminal
-- In Jupyterhub (Jupyter Workspace in Research cloud): 
-  To open a new terminal, click the + button in the file browser and select the terminal in the new Launcher tab
+- In Jupyterhub ([Jupyter Workspace](../workspaces/programming/jupyter.qmd) or [VRE Lab](../workspaces/programming/vre-lab.qmd) in Research cloud)
+  - To open a new terminal, click the + button in the file browser and select the terminal in the new Launcher tab
   ([find a short video here](https://jupyterlab.readthedocs.io/en/stable/user/terminal.html)).
-- In Rstudio (Rstudio workspace in Research cloud):
-  In the bottom left panel, click the 'terminal' tab.
+
+- In Rstudio ([Rstudio workspace](../workspaces/programming/rstudio.qmd) in Research cloud)
+  - In the bottom left panel, click the 'terminal' tab.
+
+- In [Python Desktop workspaces](../workspaces/programming/python-workbench.qmd) and [Ubuntu workspaces](../workspaces/plain/ubuntu.qmd), simply open the 'Terminal' application (found under Applications.)
+
+- [Python CLI workspaces](../workspaces/programming/python-workbench.qmd) will open a terminal by default.
+
+- To run rclone in [Windows workspaces](../workspaces/plain/windows.qmd), the installation steps are slightly different. Check out the [Windows installation manual](../manuals/rclone-windows.qmd) for more information.
 
 ### Step 2: Download and install rclone
 
@@ -21,7 +28,7 @@ Type the following command in the terminal:
 
 Type the following command. A version number will be displayed when installation was successful.
 
-```
+``` bash
 rclone version
 ```
 

--- a/docs/manuals/rclone-config.qmd
+++ b/docs/manuals/rclone-config.qmd
@@ -1,43 +1,63 @@
 ---
-title: "Configuring Rclone for surfdrive"
+title: "Configuring Rclone for Surfdrive and Researchdrive"
 ---
 
-Rclone has an interactive menu to generate a config file for you. You need to complete this menu once for each storage platform that you want to connect to. You can use Rclone for many different types of storage platforms: check the [homepage](https://rclone.org) for a list. SURFdrive and Research drive are based on ownCloud software. Platforms built on standard protocols such as WebDAV (including Yoda, Data Archive or the U: network drive of UU student and employees) are also supported but require slightly different configuration steps.
+Rclone has an interactive menu to generate a config file for you. You need to complete this menu once for each storage platform that you want to connect to. You can use Rclone for many different types of storage platforms: check the [homepage](https://rclone.org) for a list. [SURFdrive](https://www.surf.nl/en/services/storage-data-management/surfdrive) and [Research drive](https://uu.data.surf.nl) are based on Nextcloud software. Platforms built on standard protocols such as WebDAV (including Yoda, Data Archive or the U: network drive of UU student and employees) are also supported but require slightly different configuration steps.
+To transfer data from Yoda, [iBridges](../manuals/ibridges.qmd) or [iCommands](../manuals/icommands.qmd) are recommended.
 
 To check whether Rclone is available on your system:
 
-```
+``` bash
 rclone version
 ```
 
 You should see a version number displayed in the terminal.
 
+The steps below describe how to set up rclone for Surfdrive. The steps for setting up rclone for Researchdrive are similar.
+
 To start the interactive menu:
 
-```
+``` bash
 rclone config
 ```
 
-Now walk through the questions. For SURFdrive you need the following information (Rclone version 1.55.1)
+You will see a list of options and current remotes (if any). For SURFdrive you need the following information (for Rclone version 1.73.1):
 
 1. Type `n` for New remote
-2. For 'name' choose e.g. `surfdrive` (or SD)
-3. Choose option `40`for WebDAV (!depending on your Rclone version this number may be different!);
-4. Fill in the URL. You can look this up via the web portal of SURFdrive. In the top right corner click your account name. Go to settings. In the left panel, click security. At the very bottom of the page there will be a section WebDAV passwords. There is also an URL, something like: https://surfdrive.surf.nl/files/remote.php/nonshib-webdav
-   &#x20;Use this URL.
-5. Before you continue with the Rclone menu, first perform the following step via the [web portal](https://surfdrive.surf.nl) of SURFdrive. Fill in an app name (e.g. lisa) on the security settings page (same page as previous step) and click “create new app password”. The page will show a username and a password. You will need these in the following steps of the Rclone menu.
-6. Select the type of WebDAV storage system. Type: `2` for ownCloud.
-7. Type in your user name from SURFdrive (this is the username found in the web portal (step 5))
-8. Select: y) Yes type in my own password
-9. Type in your password from the web portal and type it in again for confirmation.
-10. Skip the Bearer token option by pressing enter.
-11. Choose `n` to skip the advanced config
-12. Confirm your settings by typing `y`.
-13. Choose `q` to quit the menu.
 
-Test whether everything is setup correctly by typing the following command in the terminal, if necessary change `surfdrive:` to any other name chosen in step 2.:
+2. You can choose a name for your remote e.g. `surfdrive` (or SD)
 
-```
+3. After choosing your remote name, you will be prompted to choose a storage type. Select the option for **WebDAV** (`62` for Rclone version 1.73.1. However, depending on your Rclone version this number may be different!)
+
+4. You will be asked to fill in the URL. You can look this up via the web portal of [SURFdrive](https://surfdrive.surf.nl/).
+   - In the top right corner click on your account name. Go to settings. 
+   - In the left panel, click security. Here, you can find your the url to access your files via WebDAv. It should be something like https://surfdrive.surf.nl/files/remote.php/nonshib-webdav.
+
+5. Before you continue with the Rclone config menu in your workspace terminal, first perform the following step via the [web portal](https://surfdrive.surf.nl) of SURFdrive.
+   - Fill in an **app name** (e.g. lisa) on the security settings page (same page as previous step) and click `create new app password`. 
+   - This will show a username and a password. You will need these in the following steps of the Rclone menu. **Make sure to copy the password and save it somewhere, you will not be able to access it again after closing the pop-up!** 
+
+6. Back in your terminal, enter the url from step 4.
+
+7. Select the type of WebDAV storage system. Type: `2` for Nextcloud.
+
+8. Type in your user name from SURFdrive (this is the username found in the web portal (step 5))
+
+9. You will be prompted for a password. Enter `y` to select y) Yes type in my own password
+
+10. Type in your password from the web portal and type it in again for confirmation (**Note that you will not see the password when you type it in, this is normal!**)
+
+11. Skip the Bearer token option by pressing `Enter`.
+
+12. Choose `n` to skip the advanced config
+
+13. You will see a Configuration Complete text. Confirm your settings by typing `y`. You will see a message that the new remote has been added.
+
+14. Finally, choose `q` to quit the menu.
+
+Test whether everything is setup correctly by typing the following command in the terminal, if necessary change `surfdrive:` to any other name chosen in step 2.
+
+``` bash
 rclone lsd surfdrive:
 ```
 

--- a/docs/manuals/rclone-researchcloud.qmd
+++ b/docs/manuals/rclone-researchcloud.qmd
@@ -1,10 +1,11 @@
 ---
-title: "Rclone for data transfer between cloud storage and Surf Research Cloud"
+title: "Rclone for data transfer between Surfdrive/Researchdrive and Surf Research Cloud"
 ---
 
-[Rclone](https://rclone.org/) is a convenient tool for fast data transfer between computers (PC, HPC, cloud) and cloud based storage platforms such as Surfdrive, Researchdrive, onedrive, dropbox. 
+[Rclone](https://rclone.org/) is a convenient tool for fast data transfer between computers (PC, HPC, cloud) and cloud based storage platforms such as Surfdrive and Researchdrive.
 
 It is a command line tool, so the user would need some experience with using the command line in order to user Rclone.
+If you're new to using command line, check out this introductory workshop by Utrecht University's Digital Competence Center: [Introduction to Bash](https://utrechtuniversity.github.io/workshop-introduction-to-bash/).
 
 The following steps show how you can use rclone on Research cloud for data transfer to e.g. a Jupyterhub or Rstudio workspace application.
 

--- a/docs/manuals/rclone-transferringdata.qmd
+++ b/docs/manuals/rclone-transferringdata.qmd
@@ -4,10 +4,11 @@ title: "Using Rclone"
 
 For all Rclone commands see: [https://rclone.org/commands/](https://rclone.org/commands/)
 Below are the most useful commands:
-- lsd (listing directories)
-- ls (listing files)
-- copy (copying individual files)
-- sync (copying entire folders)
+
+- `lsd` (listing directories)
+- `ls` (listing files)
+- `copy` (copying individual files)
+- `sync` (copying entire folders)
 
 ### rclone lsd
 
@@ -34,7 +35,7 @@ rclone ls surfdrive:myfolder
 
 ### rclone copy
 
-To copy a file from SURFdrive to a certain folder:
+To copy a file from SURFdrive to a certain folder in your research cloud storage volume, use the `rclone copy` command:
 
 ```
 rclone copy surfdrive:file.txt ./my_destination_folder

--- a/docs/manuals/rclone-windows.qmd
+++ b/docs/manuals/rclone-windows.qmd
@@ -1,0 +1,22 @@
+---
+Title: "Install Rclone on Windows Workspaces"
+---
+
+The steps to install Rclone on Windows workspaces are slightly different. Follows the steps below to install Rclone on Windows workspaces.
+
+1. Go to the [Rclone installation page](https://rclone.org/install/) via a web browser in your windows workspace and download the version of Rclone for Windows. The link will be something like `INTEL/AMD - 64 Bit`.
+
+2. Unzip the downloaded file in the File Explorer and move the `rclone.exe` file to a location of your choice. For example, you can create a folder called **rclone.**
+
+3. Open a powershell or command prompt terminal and navigate to the folder where you have placed the `rclone.exe` file. You can do this by using the `cd` command followed by the path to the folder (eg. `cd C:\Users\your-username\path-to-rclone-folder`).
+
+4. To check if Rclone is installed correctly, type the following command in the terminal:
+``` bash
+rclone version
+```
+You should see a version number displayed in the terminal, which means that Rclone is installed correctly. (If you get an error message, make sure you are in the correct folder where rclone.exe is located. Or try running `rclone.exe version`.)
+
+5. Now you can proceed to configure Rclone. Run `rclone.exe config`. 
+
+After this, the steps to work with Rclone in Windows workspaces are the same as described in the [Rclone configuration manual](../manuals/rclone-config.qmd) and the [Rclone data transfer manual](../manuals/rclone-transferringdata.qmd). 
+


### PR DESCRIPTION
- updates the documentation for rclone. 
- only considers surfdrive and researchdrive
- includes a guide on how to download and run rclone on windows workspaces