### PR TITLE
fix link for ai manual

### DIFF
--- a/docs/manuals.qmd
+++ b/docs/manuals.qmd
@@ -31,4 +31,4 @@ To find the best data transfer method for your situation, check out this [**Inte
 - [Setup Ollama on VRE Lab](manuals/ollama.qmd)
 - [Running long jobs](manuals/long-jobs.qmd)
 - [Connecting to Research Cloud from VS Code via SSH](manuals/vscode-to-researchcloud.qmd)
-- [Using AI powered coding assistants on Surf Research Cloud via SSH](manuals/github-copilot.qmd)
+- [Using AI powered coding assistants on Surf Research Cloud via SSH](manuals/coding-assistants.qmd)


### PR DESCRIPTION
the relative link for ai coding assistant manual used the old file which does not exist anymore. Updating here to correct file name/path